### PR TITLE
feat: add connectivity banner and sharing functionality to NicheCard

### DIFF
--- a/NicheFind/lib/main.dart
+++ b/NicheFind/lib/main.dart
@@ -9,6 +9,7 @@ import 'screens/time_commitment_screen.dart';
 import 'screens/extra_notes_screen.dart';
 import 'screens/results_screen.dart';
 import 'screens/loading_screen.dart';
+import 'widgets/connectivity_banner.dart';
 
 void main() {
   // TODO: Run the app wrapped with ChangeNotifierProvider

--- a/NicheFind/lib/widgets/connectivity_banner.dart
+++ b/NicheFind/lib/widgets/connectivity_banner.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class ConnectivityBanner extends StatefulWidget {
+  final Widget child;
+
+  const ConnectivityBanner({super.key, required this.child});
+
+  @override
+  State<ConnectivityBanner> createState() => _ConnectivityBannerState();
+}
+
+class _ConnectivityBannerState extends State<ConnectivityBanner> {
+  bool _offline = false;
+  StreamSubscription<List<ConnectivityResult>>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    final initial = await Connectivity().checkConnectivity();
+    if(mounted) setState(() => _offline = _isOffline(initial));
+    
+    _sub = Connectivity().onConnectivityChanged.listen((results) {
+      if(mounted) setState(() => _offline = _isOffline(results));
+    });
+  }
+
+  bool _isOffline(List<ConnectivityResult> results) {
+    if(results.isEmpty) return true;
+    return results.every((r) => r == ConnectivityResult.none);
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        if (_offline)
+          Material(
+            color: Colors.red.shade700,
+            child: SafeArea(
+              bottom: false,
+              child: const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                child: Row(
+                  children: [
+                    Icon(Icons.wifi_off, color: Colors.white, size: 18,),
+                    SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        "You're offline. Niche suggestions need an internet connection.",
+                        style: TextStyle(color: Colors.white, fontSize: 13),
+                      ),
+                    )
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Expanded(child: widget.child)
+      ],
+    )
+  }
+}

--- a/NicheFind/lib/widgets/niche_card.dart
+++ b/NicheFind/lib/widgets/niche_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/niche_suggestion.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class NicheCard extends StatefulWidget {
   final NicheSuggestion suggestion;
@@ -108,10 +110,58 @@ class _NicheCardState extends State<NicheCard> {
                       .toList(),
                 ),
               ),
+            const SizedBox(height: 8),
+            const Divider(height: 1),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                IconButton(
+                  tooltip: 'Search on Google',
+                  icon: const Icon(Icons.search, size: 20),
+                  onPressed: () => _openSearch(s),
+                ),
+                IconButton(
+                  tooltip: 'Share',
+                  icon: const Icon(Icons.share_outlined, size: 20),
+                  onPressed: () => _shareSuggestion(s),
+                )
+              ],
+            ),
           ],
         ),
       ),
     );
+  }
+
+  Future<void> _openSearch(NicheSuggestion s) async {
+    final query = Uri.encodeQueryComponent(s.title);
+    final url = Uri.parse('https://www.google.com/search?q=$query');
+
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  Future<void> _shareSuggestion(NicheSuggestion s) async {
+    final buffer = StringBuffer()
+      ..writeln(s.title)
+      ..writeln()
+      ..writeln(s.description)
+      ..writeln()
+      ..writeln('Demand: ${s.demand}  ·  Competition: ${s.competition}');
+
+    if (s.firstSteps.isNotEmpty) {
+      buffer
+        ..writeln()
+        ..writeln('First steps:');
+      for (final step in s.firstSteps) {
+        buffer.writeln('• $step');
+      }
+    }
+    buffer
+      ..writeln()
+      ..writeln('Found with NicheFind');
+    await Share.share(buffer.toString(), subject: s.title);
   }
 
   String _buildMetricsLabel(NicheMetrics? m) {

--- a/NicheFind/pubspec.lock
+++ b/NicheFind/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_assets:
+    dependency: transitive
+    description:
+      name: code_assets
+      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   collection:
     dependency: transitive
     description:
@@ -49,6 +57,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5+2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   fake_async:
     dependency: transitive
     description:
@@ -57,6 +105,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -83,6 +155,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  glob:
+    dependency: transitive
+    description:
+      name: glob
+      sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  hooks:
+    dependency: transitive
+    description:
+      name: hooks
+      sha256: "025f060e86d2d4c3c47b56e33caf7f93bf9283340f26d23424ebcfccf34f621e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
   http:
     dependency: "direct main"
     description:
@@ -99,6 +192,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  jni:
+    dependency: transitive
+    description:
+      name: jni
+      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  jni_flutter:
+    dependency: transitive
+    description:
+      name: jni_flutter
+      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -131,6 +240,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   markdown:
     dependency: transitive
     description:
@@ -163,6 +280,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "6ba77bb18063eebe9de401f5e6437e95e1438af0a87a3a39084fbd37c90df572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.6"
   nested:
     dependency: transitive
     description:
@@ -171,6 +304,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
+  objective_c:
+    dependency: transitive
+    description:
+      name: objective_c
+      sha256: "100a1c87616ab6ed41ec263b083c0ef3261ee6cd1dc3b0f35f8ddfa4f996fe52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.3.0"
+  package_config:
+    dependency: transitive
+    description:
+      name: package_config
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
@@ -179,6 +336,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
   provider:
     dependency: "direct main"
     description:
@@ -187,6 +416,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5+1"
+  pub_semver:
+    dependency: transitive
+    description:
+      name: pub_semver
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -248,6 +509,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:
@@ -272,6 +605,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
+  yaml:
+    dependency: transitive
+    description:
+      name: yaml
+      sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.10.3 <4.0.0"
+  flutter: ">=3.38.4"

--- a/NicheFind/pubspec.yaml
+++ b/NicheFind/pubspec.yaml
@@ -12,6 +12,9 @@ dependencies:
   http: ^1.3.0
   provider: ^6.1.0
   flutter_markdown: ^0.7.6
+  share_plus: ^10.1.0
+  url_launcher: ^6.3.1
+  connectivity_plus: ^6.0.5
 
 dev_dependencies:
   flutter_test:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ There's a gap between those two. NicheFind tries to fill it with something small
 | State | `provider` | Small state surface, no need for heavier tooling |
 | HTTP | `http` | Simple, enough for two API calls |
 | Formatting | `flutter_markdown` | Renders any markdown that slips through from DeepSeek |
-| Native features | `share_plus`, `url_launcher`, `shared_preferences`, `connectivity_plus` | Share, open on YouTube, persist form state, detect offline |
+| Native features | `share_plus`, `url_launcher`, `connectivity_plus` | Share a niche as text, open a Google search for it, detect offline state |
 | AI | DeepSeek API (`deepseek-chat`) | Cheaper per token than OpenAI, comparable quality on structured prompts |
 | Secondary data | Reddit public JSON API | Free, no key required — measures community interest as a demand signal |
 
@@ -109,6 +109,14 @@ There's a gap between those two. NicheFind tries to fill it with something small
 - No key required for the secondary Reddit API — it uses public JSON endpoints
 
 Verify your Flutter install with `flutter doctor -v` before anything else.
+
+### Platform permissions
+
+None of the three native-capability plugins require extra iOS permissions:
+
+- `share_plus` — uses the standard iOS share sheet, no Info.plist changes.
+- `url_launcher` — only opens `https://` URLs, which are allowed by default under App Transport Security. No `LSApplicationQueriesSchemes` entry needed.
+- `connectivity_plus` — no permissions on iOS; on Android the plugin auto-adds `ACCESS_NETWORK_STATE` via its own manifest.
 
 ### Clone and install
 
@@ -223,7 +231,7 @@ A few choices that will probably get asked about:
 
 **Two APIs, not one.** The original proposal leaned on DeepSeek alone. Professor feedback noted that a single API wasn't enough, and the fix genuinely makes the product better: LLM output is grounded in real Reddit community data rather than presented as fact on its own authority. Reddit was chosen over YouTube Data API because YouTube now requires billing activation on Google Cloud, which isn't appropriate for a single-user class demo. Reddit's public JSON endpoints require no key and measure actual community interest, which is a direct demand signal for niche research.
 
-**Flutter plugins over generic web wrappers.** The project brief mentioned Cordova plugins. Cordova is a different framework (hybrid web apps). In Flutter the equivalent concept is Flutter plugins from pub.dev, and the app uses four of them: `share_plus`, `url_launcher`, `shared_preferences`, and `connectivity_plus`. Each is tied to an actual user-facing feature, not just imported for the checkbox.
+**Flutter plugins over generic web wrappers.** The project brief mentioned Cordova plugins. Cordova is a different framework (hybrid web apps). In Flutter the equivalent concept is Flutter plugins from pub.dev, and the app uses three of them: `share_plus` for sharing a niche suggestion as text, `url_launcher` for opening a Google search on the niche title, and `connectivity_plus` for detecting offline state and showing a banner instead of a raw network error. Each is tied to an actual user-facing feature, not just imported for the checkbox.
 
 **Only five suggestions.** Enough to pick from, few enough to actually read. Long lists of LLM-generated ideas tend to let the generic ones drag down the good ones.
 


### PR DESCRIPTION
## Summary

Integrates three Flutter plugins so the app uses real native device capabilities instead of being pure UI. Each plugin ties to a visible user-facing feature.

Closes #3 

## Plugins chosen

| Plugin | User-facing feature |
| :-- | :-- |
| `share_plus` | Share button on each niche card — opens the native share sheet with the niche title, description, demand/competition, and first steps pre-filled |
| `url_launcher` | Search button on each niche card — opens a Google search for the niche title in the default browser |
| `connectivity_plus` | Red "You're offline" banner at the top of the app when there's no internet, instead of a raw network error later |

These three were picked over `shared_preferences`, `path_provider`, and `flutter_local_notifications` because they:

1. Work standalone — no dependency on the (still-stubbed) provider or screens
2. Give a visible demo on iOS out of the box with no extra permission setup
3. Match what the README has been promising

## What's in this PR

- `NicheFind/pubspec.yaml` — adds `share_plus`, `url_launcher`, `connectivity_plus`
- `NicheFind/lib/widgets/niche_card.dart` — new action row with Share and Search icon buttons, plus the two async handlers
- `NicheFind/lib/widgets/connectivity_banner.dart` — new widget that listens to `Connectivity().onConnectivityChanged` and shows a red SafeArea banner when all results are `ConnectivityResult.none`
- `NicheFind/lib/main.dart` — import for `ConnectivityBanner` (actual wrapping waits on the main.dart implementation issue)
- `README.md` — updated Tech stack table, Design decisions note, and a new "Platform permissions" subsection

## iOS permissions

None of the three plugins need extra Info.plist entries on iOS:

- `share_plus` uses the standard iOS share sheet.
- `url_launcher` only opens `https://` URLs, which are allowed by default under App Transport Security — no `LSApplicationQueriesSchemes` entry needed.
- `connectivity_plus` needs no iOS permissions. On Android the plugin auto-adds `ACCESS_NETWORK_STATE` via its own manifest.

Documented in the new "Platform permissions" section of the README.

## Failure behavior

- `url_launcher` is guarded with `canLaunchUrl` so a missing browser doesn't crash the card.
- `ConnectivityBanner` holds its subscription in state and cancels it on dispose. `_isOffline` treats an empty result list as offline, so edge cases don't flicker the banner.
- `share_plus` opens the system share sheet, which handles its own error UI.

## Dependencies on other issues

The `ConnectivityBanner` import in `main.dart` is currently unused because `main()` and `NicheFindApp.build()` are both still `throw UnimplementedError()`. When the main.dart implementation issue lands, `home:` inside `MaterialApp` wraps with `const ConnectivityBanner(child: WelcomeScreen())`. The integration is a single line.

## How to test

1. `flutter pub get` inside `NicheFind/`
2. Once the app is runnable end to end (after the DeepSeek + provider + screens issues merge):
   - Tap the share icon on a niche card → iOS share sheet appears with the niche text.
   - Tap the search icon → Safari opens with a Google search for the niche title.
   - Toggle airplane mode → red banner appears; turn it off → banner disappears.